### PR TITLE
Remember last used queue (category)

### DIFF
--- a/application/flicket/views/ticket_create.py
+++ b/application/flicket/views/ticket_create.py
@@ -7,6 +7,7 @@ from flask import (flash,
                    redirect,
                    url_for,
                    request,
+                   session,
                    render_template,
                    g)
 from flask_babel import gettext
@@ -22,7 +23,11 @@ from application.flicket.models.flicket_models_ext import FlicketTicketExt
 @flicket_bp.route(app.config['FLICKET'] + 'ticket_create/', methods=['GET', 'POST'])
 @login_required
 def ticket_create():
-    form = CreateTicketForm()
+    # defalut category based on last submit (get from session)
+    # using session, as information about last created ticket can be sensitive
+    # in future it can be stored in extened user model instead
+    last_category = session.get('ticket_create_last_category')
+    form = CreateTicketForm(category=last_category)
 
     if form.validate_on_submit():
 
@@ -34,6 +39,8 @@ def ticket_create():
                                                     files=request.files.getlist("file"))
 
         flash(gettext('New Ticket created.'), category='success')
+
+        session['ticket_create_last_category'] = form.category.data
 
         return redirect(url_for('flicket_bp.ticket_view', ticket_id=new_ticket.id))
 

--- a/application/flicket/views/tickets.py
+++ b/application/flicket/views/tickets.py
@@ -46,11 +46,16 @@ def tickets(page=1):
         del args['sort']
 
         response = make_response(redirect(url_for('flicket_bp.tickets', **args)))
-        response.set_cookie('tickets_sort', sort)
+        response.set_cookie('tickets_sort', sort, max_age=2419200, path=url_for('flicket_bp.tickets'))
 
         return response
 
-    sort = request.cookies.get('tickets_sort', 'priority_desc')
+    sort = request.cookies.get('tickets_sort')
+    if sort:
+        set_cookie = True
+    else:
+        sort = 'priority_desc'
+        set_cookie = False
 
     ticket_query, form = FlicketTicket.query_tickets(form, department=department, category=category, status=status,
                                                      user_id=user_id, content=content)
@@ -65,18 +70,23 @@ def tickets(page=1):
     if content:
         form.content.data = content
 
-    return render_template('flicket_tickets.html',
-                           title=title,
-                           form=form,
-                           tickets=ticket_query,
-                           page=page,
-                           number_results=number_results,
-                           status=status,
-                           department=department,
-                           category=category,
-                           user_id=user_id,
-                           sort=sort,
-                           base_url='flicket_bp.tickets')
+    response = make_response(render_template('flicket_tickets.html',
+                                             title=title,
+                                             form=form,
+                                             tickets=ticket_query,
+                                             page=page,
+                                             number_results=number_results,
+                                             status=status,
+                                             department=department,
+                                             category=category,
+                                             user_id=user_id,
+                                             sort=sort,
+                                             base_url='flicket_bp.tickets'))
+
+    if set_cookie:
+        response.set_cookie('tickets_sort', sort, max_age=2419200, path=url_for('flicket_bp.tickets'))
+
+    return response
 
 
 @flicket_bp.route(app.config['FLICKET'] + 'tickets_csv/', methods=['GET', 'POST'])
@@ -151,11 +161,16 @@ def my_tickets(page=1):
         del args['sort']
 
         response = make_response(redirect(url_for('flicket_bp.my_tickets', **args)))
-        response.set_cookie('mytickets_sort', sort)
+        response.set_cookie('my_tickets_sort', sort, max_age=2419200, path=url_for('flicket_bp.my_tickets'))
 
         return response
 
-    sort = request.cookies.get('mytickets_sort', 'priority_desc')
+    sort = request.cookies.get('my_tickets_sort')
+    if sort:
+        set_cookie = True
+    else:
+        sort = 'priority_desc'
+        set_cookie = False
 
     ticket_query, form = FlicketTicket.query_tickets(form, department=department, category=category, status=status,
                                                      user_id=user_id, content=content)
@@ -167,15 +182,20 @@ def my_tickets(page=1):
 
     title = gettext('My Tickets')
 
-    return render_template('flicket_tickets.html',
-                           title=title,
-                           form=form,
-                           tickets=ticket_query,
-                           page=page,
-                           number_results=number_results,
-                           status=status,
-                           department=department,
-                           category=category,
-                           user_id=user_id,
-                           sort=sort,
-                           base_url='flicket_bp.my_tickets')
+    response = make_response(render_template('flicket_tickets.html',
+                                             title=title,
+                                             form=form,
+                                             tickets=ticket_query,
+                                             page=page,
+                                             number_results=number_results,
+                                             status=status,
+                                             department=department,
+                                             category=category,
+                                             user_id=user_id,
+                                             sort=sort,
+                                             base_url='flicket_bp.my_tickets'))
+
+    if set_cookie:
+        response.set_cookie('my_tickets_sort', sort, max_age=2419200, path=url_for('flicket_bp.my_tickets'))
+
+    return response


### PR DESCRIPTION
Two small changes:

**Remember last used queue (category)**

When user create ticket, category has to be selected. This change preselect last used category.

It stores last used category into session, as the information about last created ticket can be sensitive.

**Cookie sort max_age set to 4 weeks**

Sort option is set in cookie, this change added max_age to the cookie, so it persists browser close and logouts. Cookie max time set to 4 weeks and path to specific view only, so cookie is send by browser only when specific view is requested.