### PR TITLE
Small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ If you are migrating from earlier version (since 0.2.1) you should ensure:
         ```
         ../../flicket/migrations/versions/253ae54f5788_change_category_config_options.py
         ../../flicket/migrations/versions/36c91aa9b3b5_new_action_model.py
+        ../../flicket/migrations/versions/70820003badd_add_logging_of_hours.py
         ../../flicket/migrations/versions/fe0f77ef3f46_migrations_before_source_code_control.py
         ```
            

--- a/application/flicket/models/flicket_models.py
+++ b/application/flicket/models/flicket_models.py
@@ -276,10 +276,9 @@ class FlicketTicket(PaginatedAPIMixin, Base):
         :return:
         """
 
-        hours = db.session.query(func.sum(FlicketPost.hours)).filter(
-            FlicketPost.ticket_id == self.id).scalar() + self.hours
+        hours = db.session.query(func.sum(FlicketPost.hours)).filter_by(ticket_id=self.id).scalar() or 0
 
-        return hours
+        return hours + self.hours
 
     def get_subscriber_emails(self):
         """


### PR DESCRIPTION
Small fixes:

1. If ticket has no posts, the original query returns `None` and it results in error `TypeError: unsupported operand type(s) for +: 'NoneType' and 'decimal.Decimal'`. So I changed query to:

```python
hours = db.session.query(func.sum(FlicketPost.hours)).filter_by(ticket_id=self.id).scalar() or 0
```

so if `None` is returned, `0` will be assigned to `hours` and later `self.hours` will be added.

2. Added into CHANGELOG info, that initial migrations are including `70820003badd_add_logging_of_hours.py`