### PR TITLE
Bugfix in change category

### DIFF
--- a/application/flicket/views/department_category.py
+++ b/application/flicket/views/department_category.py
@@ -47,6 +47,9 @@ def ticket_department_category(ticket_id=False):
                 category='warning')
             return redirect(url_for('flicket_bp.ticket_view', ticket_id=ticket.id))
 
+        # change category
+        ticket.category_id = department_category.category_id
+
         # add action record
         add_action(ticket, 'department_category', data={
             'department_category': department_category.department_category,
@@ -54,7 +57,7 @@ def ticket_department_category(ticket_id=False):
             'category': department_category.category,
             'department_id': department_category.department_id,
             'department': department_category.department})
-        
+
         db.session.commit()
 
         flash(gettext(f'You changed category of ticket: {ticket_id}'), category='success')


### PR DESCRIPTION
Change category stopped to work after some modification in the
corresponding view. So adding back the feature change category.

Another question is, if it is correct to only change category and not to
unassign user and set status to open. In my opinion, if someone is
passing ticket to another workgroup, he/she is probably not the part of
that workgroup, so unassign is wellcome, same as setting status to Open,
as the ticket goes to another workteam and the teamleader (or whatever
rules in that team are) is responsible to delegate someone to that
ticket.

But nevermind, at least the category should be changed and this fixes
it.