### PR TITLE
Fix missing lazy_gettext strings

### DIFF
--- a/docs/languages.rst
+++ b/docs/languages.rst
@@ -41,7 +41,7 @@ To add an additional local:
 
 .. code-block::
 
-    pybabel extract -F babel.cfg -o messages.pot .
+    pybabel extract -F babel.cfg -k lazy_gettext -o messages.pot .
 
 
 * To get the new translations added to the .po files:


### PR DESCRIPTION
Fix documentation to add an extra parameter to "pybabel extract" to enable export of lazy_gettext() strings.